### PR TITLE
reimplemented eva telemetry with new data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /node_modules/
+.env

--- a/client/app/screen_one/page.tsx
+++ b/client/app/screen_one/page.tsx
@@ -12,7 +12,7 @@ import ConnectionStrength from "@/components/hmd_link/conn_strength";
 import { CameraFeed } from "@/components/hmd_link/camera_feed";
 import TodoLister from "@/components/hmd_link/todo-lister";
 import ContentManager from "@/components/general/content-manager";
-import EvaTelemetry from "@/components/hmd_link/eva_telemetry";
+import BiometricTelemetry from "@/components/hmd_link/biometric_data";
  
 const NoSSR_Timers = dynamic(() => import('@/components/ui/timing'), { ssr: false })
 
@@ -21,9 +21,9 @@ const HomePage = () => {
     <div className="h-full flex flex-row gap-x-8">
       <div className="flex flex-col items-left pl-3 justify-start max-w-[600px]">
         <NoSSR_Timers />
-        <EvaTelemetry evaNumber={1} bpm={0.0} temp={0.0} oxy={0.0} className="pt-[4.2rem]" />
+        <BiometricTelemetry evaNumber={1} bpm={0.0} temp={0.0} oxy={0.0} className="pt-[4.2rem]" />
         <CameraFeed />
-        <EvaTelemetry evaNumber={2} bpm={0.0} temp={0.0} oxy={0.0} />
+        <BiometricTelemetry evaNumber={2} bpm={0.0} temp={0.0} oxy={0.0} />
         <CameraFeed />
         <TodoLister />
       </div>

--- a/client/app/screen_one/page.tsx
+++ b/client/app/screen_one/page.tsx
@@ -21,9 +21,9 @@ const HomePage = () => {
     <div className="h-full flex flex-row gap-x-8">
       <div className="flex flex-col items-left pl-3 justify-start max-w-[600px]">
         <NoSSR_Timers />
-        <EvaTelemetry evaNumber={1} bpm='' temp='' breathing_rate='' blood_pressure={['','']} className="pt-[4.2rem]" />
+        <EvaTelemetry evaNumber={1} bpm={0.0} temp={0.0} oxy={0.0} className="pt-[4.2rem]" />
         <CameraFeed />
-        <EvaTelemetry evaNumber={2} bpm={''} temp={''} breathing_rate={''} blood_pressure={['','']} />
+        <EvaTelemetry evaNumber={2} bpm={0.0} temp={0.0} oxy={0.0} />
         <CameraFeed />
         <TodoLister />
       </div>

--- a/client/components/hmd_link/biometric_data.tsx
+++ b/client/components/hmd_link/biometric_data.tsx
@@ -19,7 +19,7 @@ interface TelemetryArgs {
     oxy: number;
 }
 
-function EvaTelemetry({
+function BiometricTelemetry({
     className = '',
     evaNumber,
     bpm,
@@ -43,7 +43,7 @@ function EvaTelemetry({
                     bpmCritical || tempCritical || oxyCritical
                         ? 'bg-red-500 bg-opacity-50'
                         : 'bg-slate-600'
-                } rounded-t-3xl p-1 font-semibold items-center justify-center`}
+                } rounded-t-3xl p-1 pl-5 pr-5 font-semibold items-start gap-x-4`}
             >
                 <p>EVA {evaNumber}:</p>
                 <p
@@ -51,7 +51,7 @@ function EvaTelemetry({
                         bpmCritical ? 'underline italic font-bold' : ''
                     }`}
                 >
-                    {bpm} <span className="text-red-500">BMP</span>
+                    {bpm} <span className="text-red-500">BPM</span>
                 </p>
                 <p
                     className={`${
@@ -74,4 +74,4 @@ function EvaTelemetry({
     );
 }
 
-export default EvaTelemetry;
+export default BiometricTelemetry;

--- a/client/components/hmd_link/camera_feed.tsx
+++ b/client/components/hmd_link/camera_feed.tsx
@@ -8,7 +8,7 @@
 
 import React, { useState, useEffect } from 'react';
 import lmcc_config from "@/lmcc_config.json"
-import EvaTelemetry from './eva_telemetry';
+import BiometricTelemetry from './biometric_data';
 
 
 const fetchVideoWithoutParams = async (path: string): Promise<Response | undefined> => {

--- a/client/components/hmd_link/eva_telemetry.tsx
+++ b/client/components/hmd_link/eva_telemetry.tsx
@@ -4,24 +4,19 @@
  */
 import { useNetwork } from "@/hooks/context/network-context";
 
-const BPM_LOWER_THRESH = 60;
-const BPM_UPPER_THRESH = 100;
-const TEMP_LOWER_THRESH = 97;
-const TEMP_UPPER_THRESH = 99;
-const BR_LOWER_THRESH = 12;
-const BR_UPPER_THRESH = 20;
-const BP_SYS_LOWER_THRESH = 90;
-const BP_SYS_UPPER_THRESH = 140;
-const BP_DIA_LOWER_THRESH = 60;
-const BP_DIA_UPPER_THRESH = 120;
+const BPM_LOWER_THRESH = 50;
+const BPM_UPPER_THRESH = 160;
+const TEMP_LOWER_THRESH = 50;
+const TEMP_UPPER_THRESH = 90;
+const BR_LOWER_THRESH = 0.05;
+const BR_UPPER_THRESH = 0.15;
 
 interface TelemetryArgs {
     className?: string;
     evaNumber: number;
-    bpm: string;
-    temp: string;
-    breathing_rate: string;
-    blood_pressure: [string, string];
+    bpm: number;
+    temp: number;
+    oxy: number;
 }
 
 function EvaTelemetry({
@@ -29,27 +24,23 @@ function EvaTelemetry({
     evaNumber,
     bpm,
     temp,
-    breathing_rate,
-    blood_pressure,
+    oxy,
 }: TelemetryArgs) {
     const { getBiometricData } = useNetwork();
     const biometricDataEva = getBiometricData(evaNumber)
-    bpm = biometricDataEva.bpm;
-    temp = biometricDataEva.temp;
-    breathing_rate = biometricDataEva.breathing_rate;
-    blood_pressure = [biometricDataEva.blood_pressure[0], biometricDataEva.blood_pressure[1]];
+    bpm = biometricDataEva.telemetry.eva.heart_rate;
+    temp = biometricDataEva.telemetry.eva.temperature;
+    oxy = biometricDataEva.telemetry.eva.oxy_consumption;
 
-    let bpmCritical: boolean = parseInt(bpm, 10) > BPM_UPPER_THRESH || parseInt(bpm, 10) < BPM_LOWER_THRESH;
-    let tempCritical: boolean = parseInt(temp, 10) > TEMP_UPPER_THRESH || parseInt(temp, 10) < TEMP_LOWER_THRESH;
-    let breathingRateCritical: boolean = parseInt(breathing_rate, 10) > BR_UPPER_THRESH || parseInt(breathing_rate, 10) < BR_LOWER_THRESH;
-    let bloodPressureCritical: boolean = parseInt(blood_pressure[0], 10) > BP_SYS_UPPER_THRESH || parseInt(blood_pressure[0], 10) < BP_SYS_LOWER_THRESH
-    || parseInt(blood_pressure[1], 10) > BP_DIA_UPPER_THRESH || parseInt(blood_pressure[1], 10) < BP_DIA_LOWER_THRESH;
+    let bpmCritical: boolean = bpm > BPM_UPPER_THRESH || bpm < BPM_LOWER_THRESH;
+    let tempCritical: boolean = temp > TEMP_UPPER_THRESH || temp < TEMP_LOWER_THRESH;
+    let oxyCritical: boolean = oxy > BR_UPPER_THRESH || oxy < BR_LOWER_THRESH;
 
     return (
         <div className={className}>
             <div
                 className={`flex flex-row gap-x-6 text-xl ${
-                    bpmCritical || tempCritical || breathingRateCritical || bloodPressureCritical
+                    bpmCritical || tempCritical || oxyCritical
                         ? 'bg-red-500 bg-opacity-50'
                         : 'bg-slate-600'
                 } rounded-t-3xl p-1 font-semibold items-center justify-center`}
@@ -60,7 +51,7 @@ function EvaTelemetry({
                         bpmCritical ? 'underline italic font-bold' : ''
                     }`}
                 >
-                    {bpm} <span className="text-red-500">BPM</span>
+                    {bpm} <span className="text-red-500">BMP</span>
                 </p>
                 <p
                     className={`${
@@ -72,19 +63,11 @@ function EvaTelemetry({
                 </p>
                 <p
                     className={`${
-                        breathingRateCritical ? 'underline italic font-bold' : ''
+                        oxyCritical ? 'underline italic font-bold' : ''
                     }`}
                 >
-                    {breathing_rate}
-                    <span className="text-blue-400"> BRPM</span>
-                </p>
-                <p
-                    className={`${
-                        bloodPressureCritical ? 'underline italic font-bold' : ''
-                    }`}
-                >
-                    {blood_pressure[0]}/{blood_pressure[1]}
-                    <span className="text-orange-400"> mmHg</span>
+                    {oxy}
+                    <span className="text-blue-400"> PSI/MIN</span>
                 </p>
             </div>
         </div>

--- a/client/hooks/context/network-context.tsx
+++ b/client/hooks/context/network-context.tsx
@@ -9,9 +9,17 @@ import {
 	SpecData,
 	SpecItem,
 	EVASpecItems,
-	Biometric,
+	Biometrics,
 	RoverData,
 } from "../types";
+import { 
+    defaultPanicValue,
+    defaultRoverValue,
+    defaultGEOJSONValue,
+    defaultSpecValue, 
+    defaultTimerValue, 
+    defaultBiometricValue
+} from "../defaults"
 
 ////////////////////////////////////////////////
 
@@ -23,68 +31,6 @@ const formatTime = (seconds: number) => {  //build formatted timer
 	return [hours, minutes, secs].map(v => v < 10 ? "0" + v : v).join(":");
 };
 
-const defaultPanicValue: PanicData = {
-    infoWarning: "", 
-    todoItems: [], 
-    isWarning: false,
-}
-
-const defaultTimerValue: TimerType = {
-	mission: "00:00:00",
-	uia: "00:00:00",
-	spec: "00:00:00",
-	dcu: "00:00:00",
-	rover: "00:00:00"
-}
-
-const defaultGEOJSONValue: GeoJSON = {
-	type: 'FeatureCollection',
-	features: []
-}
-
-const defaultSpecValue: EVASpecItems = {
-	eva1: null,
-	eva2: null 
-}
-
-
-const defaultRoverValue: RoverData = { 
-	rover: {
-		posx: 0,
-		posy: 0,
-		qr_id: 0,
-	}
-}
-
-const defaultBiometricValue: Biometric = { 
-	telemetry: {
-		eva: {
-			batt_time_left: 0.0,
-			co2_production: 0.0,
-			coolant_gas_pressure: 0.0,
-			coolant_liquid_pressure: 0.0,
-			coolant_m1: 0.0,
-			fan_pri_rpm: 0.0,
-			fan_sec_rpm: 0.0,
-			heart_rate: 0.0,
-			helmet_pressure_co2: 0.0,
-			oxy_consumption: 0.0,
-			oxy_pri_pressure: 0.0,
-			oxy_pri_storage: 0.0,
-			oxy_sec_pressure: 0.0,
-			oxy_sec_storage: 0.0,
-			oxy_time_left: 0.0,
-			scrubber_a_co2_storage: 0.0,
-			scrubber_b_co2_storage: 0.0,
-			suit_pressure_co2: 0.0,
-			suit_pressure_other: 0.0,
-			suit_pressure_oxy: 0.0,
-			suit_pressure_total: 0.0,
-			temperature: 0.0,
-		}
-	}
-}
-
 ////////////////////////////////////////////////////////////////
 
 interface NetworkContextType {
@@ -92,7 +38,7 @@ interface NetworkContextType {
 	getNotifData: () => PanicData;
 	getGeoJSONData: () => GeoJSON;
 	getSpecData: () => EVASpecItems;
-	getBiometricData: (evaNumber: number) => Biometric;
+	getBiometricData: (evaNumber: number) => Biometrics;
 	getRoverData: () => RoverData;
 }
 
@@ -120,8 +66,8 @@ export const NetworkProvider = ({ children }: any) => {
 	const [mapGeoJSON, setMapGeoJSON] = useState<GeoJSON>();
 	const [eva1SpecItem, setEVA1SpecItem] = useState<SpecItem>();
 	const [eva2SpecItem, setEVA2SpecItem] = useState<SpecItem>();
-	const [biometricDataEva1, setBiometricDataEva1] = useState<Biometric>(defaultBiometricValue);
-	const [biometricDataEva2, setBiometricDataEva2] = useState<Biometric>(defaultBiometricValue);
+	const [biometricDataEva1, setBiometricDataEva1] = useState<Biometrics>(defaultBiometricValue);
+	const [biometricDataEva2, setBiometricDataEva2] = useState<Biometrics>(defaultBiometricValue);
 	const [roverData, setRoverData] = useState<RoverData>(defaultRoverValue); 
 
 	useEffect(() => {
@@ -174,7 +120,7 @@ export const NetworkProvider = ({ children }: any) => {
 					throw new Error('Map Info is undefined')
 				}
 
-				const biometricData = await fetchWithoutParams<Biometric>('tss/telemetry');
+				const biometricData = await fetchWithoutParams<Biometrics>('tss/telemetry');
 				if (biometricData) {
 					setBiometricDataEva1(
 						{
@@ -208,7 +154,7 @@ export const NetworkProvider = ({ children }: any) => {
 					)
 				}
 				else {
-					throw new Error('Biometric Data is undefined')
+					throw new Error('Biometric Data (EVA 1) is undefined')
 				}
 
 				if (biometricData) {
@@ -244,7 +190,7 @@ export const NetworkProvider = ({ children }: any) => {
 					) 
 				}
 				else {
-					throw new Error('Biometric Data is undefined')
+					throw new Error('Biometric Data (EVA 2) is undefined')
 				}
 
 				const specData = await fetchWithoutParams<SpecData>("mission/spec");
@@ -312,7 +258,7 @@ export const NetworkProvider = ({ children }: any) => {
 		return roverData || defaultRoverValue
 	}
 
-	const getBiometricData = (evaNumber: number): Biometric => {
+	const getBiometricData = (evaNumber: number): Biometrics => {
 		let biometricData;
 		if (evaNumber === 1) {
 			biometricData = biometricDataEva1;

--- a/client/hooks/context/network-context.tsx
+++ b/client/hooks/context/network-context.tsx
@@ -9,8 +9,7 @@ import {
 	SpecData,
 	SpecItem,
 	EVASpecItems,
-	BiometricData,
-	BiometricItem,
+	Biometric,
 	RoverData,
 } from "../types";
 
@@ -36,7 +35,6 @@ const defaultTimerValue: TimerType = {
 	spec: "00:00:00",
 	dcu: "00:00:00",
 	rover: "00:00:00"
-	
 }
 
 const defaultGEOJSONValue: GeoJSON = {
@@ -49,41 +47,41 @@ const defaultSpecValue: EVASpecItems = {
 	eva2: null 
 }
 
-const defaultBiometricDataValue: BiometricData = {
-	eva: '',
-    data: {
-        blood_pressure: {
-            unit: '',
-            value: ''
-        },
-        body_temperature: {
-            unit: '',
-            value: ''
-        },
-        breathing_rate: {
-            unit: '',
-            value: ''
-        },
-        heart_rate: {
-            unit: '',
-            value: ''
-        }
-    }
-}
-
-const defaultBiometricItemValue: BiometricItem = {
-	eva: '',
-	bpm: '',
-	temp: '',
-	breathing_rate: '',
-	blood_pressure: [],
-}
 
 const defaultRoverValue: RoverData = { 
 	rover: {
 		posx: 0,
 		posy: 0,
 		qr_id: 0,
+	}
+}
+
+const defaultBiometricValue: Biometric = { 
+	telemetry: {
+		eva: {
+			batt_time_left: 0.0,
+			co2_production: 0.0,
+			coolant_gas_pressure: 0.0,
+			coolant_liquid_pressure: 0.0,
+			coolant_m1: 0.0,
+			fan_pri_rpm: 0.0,
+			fan_sec_rpm: 0.0,
+			heart_rate: 0.0,
+			helmet_pressure_co2: 0.0,
+			oxy_consumption: 0.0,
+			oxy_pri_pressure: 0.0,
+			oxy_pri_storage: 0.0,
+			oxy_sec_pressure: 0.0,
+			oxy_sec_storage: 0.0,
+			oxy_time_left: 0.0,
+			scrubber_a_co2_storage: 0.0,
+			scrubber_b_co2_storage: 0.0,
+			suit_pressure_co2: 0.0,
+			suit_pressure_other: 0.0,
+			suit_pressure_oxy: 0.0,
+			suit_pressure_total: 0.0,
+			temperature: 0.0,
+		}
 	}
 }
 
@@ -94,7 +92,7 @@ interface NetworkContextType {
 	getNotifData: () => PanicData;
 	getGeoJSONData: () => GeoJSON;
 	getSpecData: () => EVASpecItems;
-	getBiometricData: (evaNumber: number) => BiometricItem;
+	getBiometricData: (evaNumber: number) => Biometric;
 	getRoverData: () => RoverData;
 }
 
@@ -103,7 +101,7 @@ const defaultNetworkValue: NetworkContextType = {
 	getNotifData: () => defaultPanicValue,
 	getGeoJSONData: () => defaultGEOJSONValue,
 	getSpecData: () => defaultSpecValue,
-	getBiometricData: (evaNumber: number) => defaultBiometricItemValue,
+	getBiometricData: (evaNumber: number) => defaultBiometricValue,
 	getRoverData: () => defaultRoverValue,
 };
 
@@ -122,8 +120,8 @@ export const NetworkProvider = ({ children }: any) => {
 	const [mapGeoJSON, setMapGeoJSON] = useState<GeoJSON>();
 	const [eva1SpecItem, setEVA1SpecItem] = useState<SpecItem>();
 	const [eva2SpecItem, setEVA2SpecItem] = useState<SpecItem>();
-	const [biometricDataEva1, setBiometricDataEva1] = useState<BiometricData>(defaultBiometricDataValue);
-	const [biometricDataEva2, setBiometricDataEva2] = useState<BiometricData>(defaultBiometricDataValue);
+	const [biometricDataEva1, setBiometricDataEva1] = useState<Biometric>(defaultBiometricValue);
+	const [biometricDataEva2, setBiometricDataEva2] = useState<Biometric>(defaultBiometricValue);
 	const [roverData, setRoverData] = useState<RoverData>(defaultRoverValue); 
 
 	useEffect(() => {
@@ -176,17 +174,74 @@ export const NetworkProvider = ({ children }: any) => {
 					throw new Error('Map Info is undefined')
 				}
 
-				const biometricDataEva1 = await fetchWithoutParams<BiometricData>('api/v0?get=biodata&eva=one');
-				const biometricDataEva2 = await fetchWithoutParams<BiometricData>('api/v0?get=biodata&eva=two');
-				if (biometricDataEva1) {
-					setBiometricDataEva1(biometricDataEva1)
+				const biometricData = await fetchWithoutParams<Biometric>('tss/telemetry');
+				if (biometricData) {
+					setBiometricDataEva1(
+						{
+							telemetry: {
+								eva: {
+									batt_time_left: biometricData.telemetry.eva1.batt_time_left,
+									co2_production: biometricData.telemetry.eva1.co2_production,
+									coolant_gas_pressure: biometricData.telemetry.eva1.coolant_gas_pressure,
+									coolant_liquid_pressure: biometricData.telemetry.eva1.coolant_liquid_pressure,
+									coolant_m1: biometricData.telemetry.eva1.coolant_m1,
+									fan_pri_rpm: biometricData.telemetry.eva1.fan_pri_rpm,
+									fan_sec_rpm: biometricData.telemetry.eva1.fan_sec_rpm,
+									heart_rate: biometricData.telemetry.eva1.heart_rate,
+									helmet_pressure_co2: biometricData.telemetry.eva1.helmet_pressure_co2,
+									oxy_consumption: biometricData.telemetry.eva1.oxy_consumption,
+									oxy_pri_pressure: biometricData.telemetry.eva1.oxy_pri_pressure,
+									oxy_pri_storage: biometricData.telemetry.eva1.oxy_pri_storage,
+									oxy_sec_pressure: biometricData.telemetry.eva1.oxy_sec_pressure,
+									oxy_sec_storage: biometricData.telemetry.eva1.oxy_sec_storage,
+									oxy_time_left: biometricData.telemetry.eva1.oxy_time_left,
+									scrubber_a_co2_storage: biometricData.telemetry.eva1.scrubber_a_co2_storage,
+									scrubber_b_co2_storage: biometricData.telemetry.eva1.scrubber_b_co2_storage,
+									suit_pressure_co2: biometricData.telemetry.eva1.suit_pressure_co2,
+									suit_pressure_other:  biometricData.telemetry.eva1.suit_pressure_other,
+									suit_pressure_oxy:  biometricData.telemetry.eva1.suit_pressure_oxy,
+									suit_pressure_total:  biometricData.telemetry.eva1.suit_pressure_total,
+									temperature:  biometricData.telemetry.eva1.temperature,
+									}
+							}
+						}
+					)
 				}
 				else {
 					throw new Error('Biometric Data is undefined')
 				}
 
-				if (biometricDataEva2) {
-					setBiometricDataEva2(biometricDataEva2) 
+				if (biometricData) {
+					setBiometricDataEva2(
+						{
+							telemetry: {
+								eva: {
+									batt_time_left: biometricData.telemetry.eva2.batt_time_left,
+									co2_production: biometricData.telemetry.eva2.co2_production,
+									coolant_gas_pressure: biometricData.telemetry.eva2.coolant_gas_pressure,
+									coolant_liquid_pressure: biometricData.telemetry.eva2.coolant_liquid_pressure,
+									coolant_m1: biometricData.telemetry.eva2.coolant_m1,
+									fan_pri_rpm: biometricData.telemetry.eva2.fan_pri_rpm,
+									fan_sec_rpm: biometricData.telemetry.eva2.fan_sec_rpm,
+									heart_rate: biometricData.telemetry.eva2.heart_rate,
+									helmet_pressure_co2: biometricData.telemetry.eva2.helmet_pressure_co2,
+									oxy_consumption: biometricData.telemetry.eva2.oxy_consumption,
+									oxy_pri_pressure: biometricData.telemetry.eva2.oxy_pri_pressure,
+									oxy_pri_storage: biometricData.telemetry.eva2.oxy_pri_storage,
+									oxy_sec_pressure: biometricData.telemetry.eva2.oxy_sec_pressure,
+									oxy_sec_storage: biometricData.telemetry.eva2.oxy_sec_storage,
+									oxy_time_left: biometricData.telemetry.eva2.oxy_time_left,
+									scrubber_a_co2_storage: biometricData.telemetry.eva2.scrubber_a_co2_storage,
+									scrubber_b_co2_storage: biometricData.telemetry.eva2.scrubber_b_co2_storage,
+									suit_pressure_co2: biometricData.telemetry.eva2.suit_pressure_co2,
+									suit_pressure_other: biometricData.telemetry.eva2.suit_pressure_other,
+									suit_pressure_oxy: biometricData.telemetry.eva2.suit_pressure_oxy,
+									suit_pressure_total: biometricData.telemetry.eva2.suit_pressure_total,
+									temperature: biometricData.telemetry.eva2.temperature,
+									}
+							}
+						}
+					) 
 				}
 				else {
 					throw new Error('Biometric Data is undefined')
@@ -257,7 +312,7 @@ export const NetworkProvider = ({ children }: any) => {
 		return roverData || defaultRoverValue
 	}
 
-	const getBiometricData = (evaNumber: number): BiometricItem => {
+	const getBiometricData = (evaNumber: number): Biometric => {
 		let biometricData;
 		if (evaNumber === 1) {
 			biometricData = biometricDataEva1;
@@ -266,13 +321,33 @@ export const NetworkProvider = ({ children }: any) => {
 		} else {
 			throw new Error(`Invalid Eva number: ${evaNumber}`);
 		}
-	
 			return {
-				eva: biometricData.eva,
-				bpm: biometricData.data.heart_rate.value,
-				temp: biometricData.data.body_temperature.value,
-				breathing_rate: biometricData.data.breathing_rate.value,
-				blood_pressure: [biometricData.data.blood_pressure.value.slice(0,1),biometricData.data.blood_pressure.value.slice(1,2)]
+				telemetry: {
+					eva: {
+						batt_time_left: biometricData.telemetry.eva.batt_time_left,
+						co2_production: biometricData.telemetry.eva.co2_production,
+						coolant_gas_pressure: biometricData.telemetry.eva.coolant_gas_pressure,
+						coolant_liquid_pressure: biometricData.telemetry.eva.coolant_liquid_pressure,
+						coolant_m1: biometricData.telemetry.eva.coolant_m1,
+						fan_pri_rpm: biometricData.telemetry.eva.fan_pri_rpm,
+						fan_sec_rpm: biometricData.telemetry.eva.fan_sec_rpm,
+						heart_rate: biometricData.telemetry.eva.heart_rate,
+						helmet_pressure_co2: biometricData.telemetry.eva.helmet_pressure_co2,
+						oxy_consumption: biometricData.telemetry.eva.oxy_consumption,
+						oxy_pri_pressure: biometricData.telemetry.eva.oxy_pri_pressure,
+						oxy_pri_storage: biometricData.telemetry.eva.oxy_pri_storage,
+						oxy_sec_pressure: biometricData.telemetry.eva.oxy_sec_pressure,
+						oxy_sec_storage: biometricData.telemetry.eva.oxy_sec_storage,
+						oxy_time_left: biometricData.telemetry.eva.oxy_time_left,
+						scrubber_a_co2_storage: biometricData.telemetry.eva.scrubber_a_co2_storage,
+						scrubber_b_co2_storage: biometricData.telemetry.eva.scrubber_b_co2_storage,
+						suit_pressure_co2: biometricData.telemetry.eva.suit_pressure_co2,
+						suit_pressure_other: biometricData.telemetry.eva.suit_pressure_other,
+						suit_pressure_oxy: biometricData.telemetry.eva.suit_pressure_oxy,
+						suit_pressure_total: biometricData.telemetry.eva.suit_pressure_total,
+						temperature: biometricData.telemetry.eva.temperature,
+					}
+				}
 			};
 	};
 

--- a/client/hooks/defaults.ts
+++ b/client/hooks/defaults.ts
@@ -1,0 +1,85 @@
+import { 
+	GeoJSON, 
+	PanicData,
+	TimerType,
+	SpecData,
+	SpecItem,
+	EVASpecItems,
+	Biometrics,
+	RoverData,
+} from "./types";
+
+///////////////////////////////////////
+
+const defaultPanicValue: PanicData = {
+    infoWarning: "", 
+    todoItems: [], 
+    isWarning: false,
+}
+
+const defaultTimerValue: TimerType = {
+	mission: "00:00:00",
+	uia: "00:00:00",
+	spec: "00:00:00",
+	dcu: "00:00:00",
+	rover: "00:00:00"
+}
+
+const defaultGEOJSONValue: GeoJSON = {
+	type: 'FeatureCollection',
+	features: []
+}
+
+const defaultSpecValue: EVASpecItems = {
+	eva1: null,
+	eva2: null 
+}
+
+
+const defaultRoverValue: RoverData = { 
+	rover: {
+		posx: 0,
+		posy: 0,
+		qr_id: 0,
+	}
+}
+
+const defaultBiometricValue: Biometrics = { 
+	telemetry: {
+		eva: {
+			batt_time_left: 0.0,
+			co2_production: 0.0,
+			coolant_gas_pressure: 0.0,
+			coolant_liquid_pressure: 0.0,
+			coolant_m1: 0.0,
+			fan_pri_rpm: 0.0,
+			fan_sec_rpm: 0.0,
+			heart_rate: 0.0,
+			helmet_pressure_co2: 0.0,
+			oxy_consumption: 0.0,
+			oxy_pri_pressure: 0.0,
+			oxy_pri_storage: 0.0,
+			oxy_sec_pressure: 0.0,
+			oxy_sec_storage: 0.0,
+			oxy_time_left: 0.0,
+			scrubber_a_co2_storage: 0.0,
+			scrubber_b_co2_storage: 0.0,
+			suit_pressure_co2: 0.0,
+			suit_pressure_other: 0.0,
+			suit_pressure_oxy: 0.0,
+			suit_pressure_total: 0.0,
+			temperature: 0.0,
+		}
+	}
+}
+
+///////////////////////////////////////////
+
+export { 
+    defaultPanicValue,
+    defaultRoverValue,
+    defaultGEOJSONValue,
+    defaultSpecValue, 
+    defaultTimerValue, 
+    defaultBiometricValue
+}

--- a/client/hooks/types.ts
+++ b/client/hooks/types.ts
@@ -73,26 +73,34 @@ interface EVASpecItems {
 // BIOMETRICDATA /////////////////////////////////////////////////////////////
 
 interface BiometricData {
-    eva: string;
-    data: {
-        heart_rate: BiometricMeasurement;
-        body_temperature: BiometricMeasurement;
-        breathing_rate: BiometricMeasurement;
-        blood_pressure: BiometricMeasurement;
-    };
+    batt_time_left: number;
+    co2_production: number;
+    coolant_gas_pressure: number;
+    coolant_liquid_pressure: number;
+    coolant_m1: number;
+    fan_pri_rpm: number;
+    fan_sec_rpm: number;
+    heart_rate: number;
+    helmet_pressure_co2: number;
+    oxy_consumption: number;
+    oxy_pri_pressure: number;
+    oxy_pri_storage: number;
+    oxy_sec_pressure: number;
+    oxy_sec_storage: number;
+    oxy_time_left: number;
+    scrubber_a_co2_storage: number;
+    scrubber_b_co2_storage: number;
+    suit_pressure_co2: number;
+    suit_pressure_other: number;
+    suit_pressure_oxy: number;
+    suit_pressure_total: number;
+    temperature: number;
 }
 
-interface BiometricMeasurement {
-    unit: string;
-    value: string;
-}
-
-interface BiometricItem {
-    eva: string | number;
-    bpm: string;
-    temp: string;
-    breathing_rate: string;
-    blood_pressure: (string)[];
+interface Biometric {
+    telemetry: {
+        [eva: string]: BiometricData;
+    }
 }
 
 ///// ROVER /////////////////////////////////////////////////////////////
@@ -116,7 +124,7 @@ export type {
     SpecData,
     SpecItem,
     EVASpecItems, 
+    Biometric,
     BiometricData,
-    BiometricItem, 
     RoverData,
 }

--- a/client/hooks/types.ts
+++ b/client/hooks/types.ts
@@ -97,7 +97,7 @@ interface BiometricData {
     temperature: number;
 }
 
-interface Biometric {
+interface Biometrics {
     telemetry: {
         [eva: string]: BiometricData;
     }
@@ -124,7 +124,7 @@ export type {
     SpecData,
     SpecItem,
     EVASpecItems, 
-    Biometric,
+    Biometrics,
     BiometricData,
     RoverData,
 }


### PR DESCRIPTION
set new thresholds for heart rate, temperature and oxygen consumption based on 
https://github.com/SUITS-Techteam/TSS_2024/blob/main/SUITS_TelemetryValueRanges.pdf

changed screen one to only hold values of heart rate (BMP) , temperature (F) , and oxygen consumption (PSI/MIN)

created new interface types for all:
```
 interface BiometricData {
    batt_time_left: number;
    co2_production: number;
    coolant_gas_pressure: number;
    coolant_liquid_pressure: number;
    coolant_m1: number;
    fan_pri_rpm: number;
    fan_sec_rpm: number;
    heart_rate: number;
    helmet_pressure_co2: number;
    oxy_consumption: number;
    oxy_pri_pressure: number;
    oxy_pri_storage: number;
    oxy_sec_pressure: number;
    oxy_sec_storage: number;
    oxy_time_left: number;
    scrubber_a_co2_storage: number;
    scrubber_b_co2_storage: number;
    suit_pressure_co2: number;
    suit_pressure_other: number;
    suit_pressure_oxy: number;
    suit_pressure_total: number;
    temperature: number;
  }
```

created a call to **/tss/telemetry** which set values and returned those values based on each eva 

generalized the default and return values for use within screen two regarding the values that were unused for screen 1

currently the values are constant because there is no data source, but the values are being accessed correctly from each eva, **_in which batt_time_left is an example value where there is a clear difference in data between eva1 and eva2, which will not be shown in screen1 and is currently taken out_**

```
"telemetry": {
    "eva1": {
      "heart_rate": 90.0,
      "temperature": 70.0
      "oxy_consumption": 0.0,
      "batt_time_left": 5077.148926,
    },
    "eva2": {
      "heart_rate": 90.0,
      "temperature": 70.0
      "oxy_consumption": 0.0,
      "batt_time_left": 3384.893799,
    },
}
```
![image](https://github.com/Team-Cartographer/SUITS-2024-LMCC/assets/149543946/393e528d-cfb1-4a3e-aaad-8f0a963f661f)


will revise if design changes are needed, more values need to be displayed on screen1 or implementing the constant updating of values needs to be added